### PR TITLE
Directory Mapping corrected

### DIFF
--- a/modman
+++ b/modman
@@ -1,1 +1,2 @@
-app/*       app
+app/code/community/Fballiano/AutodeleteProductImages  app/code/community/Fballiano/AutodeleteProductImages
+app/etc/modules/Fballiano_AutodeleteProductImages.xml app/etc/modules/Fballiano_AutodeleteProductImages.xml


### PR DESCRIPTION
Inserted directory mappings to allow correct installation using composer.

See https://github.com/fballiano/magento-autodelete-product-images/issues/1
